### PR TITLE
feat: convert JS worker to Scala.js with scala-cli

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Scala CLI
         uses: VirtusLab/scala-cli-setup@main
       - name: Publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
+      - name: Install Scala CLI
+        uses: VirtusLab/scala-cli-setup@main
       - name: Publish
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          preCommands: npm install && npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ node_modules/
 .idea
 .dev.vars
 .wrangler
+src/index.js
+.scala-build/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules/
 .wrangler
 src/index.js
 .scala-build/
+.bsp

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,3 @@
+version = 3.11.1
+runner.dialect = scala3
+align.preset = more

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "generate",
       "version": "1.0.0",
       "devDependencies": {
-        "wrangler": "^4.101.0"
+        "wrangler": "^4.103.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260616.1.tgz",
-      "integrity": "sha512-8QaDRQABkwkwoeviNiyScol7EQgXfGsPNSyUn52GiXObthY4XPiokoJsgDSDNcAelHjEvDLmdvQBHPK8YvGn4A==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260617.1.tgz",
+      "integrity": "sha512-jWwmgEVVWbsHNrLSNXzwjJaH90VzRxq1cWkQFUidxyeUPnMxemeNE8I9qFAfrpzGgE11e9sKDcE3ettJW08swQ==",
       "cpu": [
         "x64"
       ],
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260616.1.tgz",
-      "integrity": "sha512-xEhiZQ62CBJ+vyKSmM13rkK/wB1kLP5sKFkF3+P+3R/c2bmnSG3Vcd5FfXUu9V0PdC+KlR02nByvZjqEw2N6Ag==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260616.1.tgz",
-      "integrity": "sha512-p5laSYPiRUMHaLkneaZ9ZfIkNpmEnGFwgYmXtfcHJutTfEd8o3IBnsUVRSbPL+phcshKqmapLsQSxDEX6WSFfA==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260617.1.tgz",
+      "integrity": "sha512-FMnaAKXe4Cfd8TQurCVd9fs2XQVBFRCsP+Id/SRdUv89MlwYu9zXfoyx6BxM+brPTIUK38SHbo8iaxiwzLi9JQ==",
       "cpu": [
         "x64"
       ],
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260616.1.tgz",
-      "integrity": "sha512-XQ7GonEl8ORvbz5fhe8Eyw2t/j09Li0KbXJxaldA318E+syF+PPTc4IRQudgqPWzzdzkH5nF7PuMOGySLSjFFw==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260616.1.tgz",
-      "integrity": "sha512-RaDVF9bSbPiPTq6vHYrgnv1TcQEcYnOr0WB3hWJ4yg2fBfpi2ygU6cYPuFeDwyFE9aPW5S6FBAkNmpKYueK4DQ==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260617.1.tgz",
+      "integrity": "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==",
       "cpu": [
         "x64"
       ],
@@ -147,9 +147,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -164,9 +164,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -198,9 +198,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -215,9 +215,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -249,9 +249,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -283,9 +283,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -300,9 +300,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -317,9 +317,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -334,9 +334,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -368,9 +368,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -385,9 +385,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -402,9 +402,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -419,9 +419,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -436,9 +436,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -453,9 +453,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -487,9 +487,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -504,9 +504,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -521,9 +521,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -538,9 +538,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -572,9 +572,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1244,9 +1244,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1257,32 +1257,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/fsevents": {
@@ -1311,17 +1311,17 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260616.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260616.0.tgz",
-      "integrity": "sha512-cEpzoNgSWjedzYmhJvttUPmL4Jk6nSzzeNNi118T5zwnmYP9fnM8UXwFU/Qa/1qoQ4SzGqtM1Q7tinHvHvIGtw==",
+      "version": "4.20260617.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260617.1.tgz",
+      "integrity": "sha512-Go3/gzStm99QHptsSgU+q1S+xDfLoRgwjJNY80kaTVi0ENhTyqKq+sc4xZiWBSbM7uUcJwmzm8+QFKtcYLJ9nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
-        "undici": "7.24.8",
-        "workerd": "1.20260616.1",
-        "ws": "8.20.1",
+        "undici": "7.28.0",
+        "workerd": "1.20260617.1",
+        "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
       "bin": {
@@ -1345,9 +1345,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1424,9 +1424,9 @@
       "optional": true
     },
     "node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1444,9 +1444,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260616.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260616.1.tgz",
-      "integrity": "sha512-aRGWYxviSjYZwyu97pCr5GyJ9ObpgmNcfZZs3/o+kG7Wz3SBTqA8d8uhNueY5u7ADeUp2ibJvK6mXkFLrUmPgg==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260617.1.tgz",
+      "integrity": "sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1457,28 +1457,28 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260616.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260616.1",
-        "@cloudflare/workerd-linux-64": "1.20260616.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260616.1",
-        "@cloudflare/workerd-windows-64": "1.20260616.1"
+        "@cloudflare/workerd-darwin-64": "1.20260617.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260617.1",
+        "@cloudflare/workerd-linux-64": "1.20260617.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260617.1",
+        "@cloudflare/workerd-windows-64": "1.20260617.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.101.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.101.0.tgz",
-      "integrity": "sha512-dZDDiRcT7MiA09lBDxWKmiL/iybEZ+SZe3IZmnVx1m1n1DOo730vOY5SeO7z9xFK8a/+vhGKDYB8mDXrvzEr5g==",
+      "version": "4.103.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.103.0.tgz",
+      "integrity": "sha512-3Lv1P5t2xcSEkSTKtG+Lz+3JFryuU7YPLkaCUj7gNe+CJsjZJLtUwqsh1x595QBxkIbCE0GAvDx2DCJUU4+oqw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.5.0",
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260616.0",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260617.1",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260616.1"
+        "workerd": "1.20260617.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -1492,7 +1492,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260616.1"
+        "@cloudflare/workers-types": "^4.20260617.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -1501,9 +1501,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "generate",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "scripts": {
-    "build": "scala-cli --power package src/index.scala --js --js-module-kind es -o src/index.js -f",
+    "build": "scala-cli --power package . -o src/index.js -f",
     "start": "npm run build && wrangler dev",
-    "deploy": "npm run build && wrangler deploy"
+    "deploy": "npm run build && wrangler deploy",
+    "update": "npm outdated; npm install -g npm-check-updates; ncu; ncu -u; npm install"
   },
   "devDependencies": {
-    "wrangler": "^4.101.0"
+    "wrangler": "^4.103.0"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "generate",
   "version": "1.0.0",
+  "scripts": {
+    "build": "scala-cli --power package src/index.scala --js --js-module-kind es -o src/index.js -f",
+    "start": "npm run build && wrangler dev",
+    "deploy": "npm run build && wrangler deploy"
+  },
   "devDependencies": {
     "wrangler": "^4.101.0"
   },

--- a/project.scala
+++ b/project.scala
@@ -1,0 +1,5 @@
+//> using scala "3"
+//> using file src/index.scala
+//> using platform js
+//> using jsModuleKind es
+//> using jvm graalvm-community:21

--- a/src/index.scala
+++ b/src/index.scala
@@ -1,77 +1,97 @@
-export default {
-    async fetch(request, env, ctx) {
-        const realIp = request.headers.get("x-real-ip");
-        const connectingIp = request.headers.get("cf-connecting-ip");
-        //const url1 = `https://ipinfo.io/${realIp}?token=${env.ipinfo_token}`;
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+import scala.concurrent.Future
+import scala.scalajs.js.JSConverters._
 
-        async function apiCall(url) {
-            const response = await fetch(url);
-            const result = await response.text();
-            return JSON.parse(result);
-        }
+@JSExportTopLevel("default")
+object Worker extends js.Object {
+  val fetch: js.Function3[js.Dynamic, js.Dynamic, js.Dynamic, js.Promise[js.Dynamic]] = { (request: js.Dynamic, env: js.Dynamic, ctx: js.Dynamic) =>
+    val realIp = request.headers.get("x-real-ip").asInstanceOf[String]
+    val connectingIp = request.headers.get("cf-connecting-ip").asInstanceOf[String]
+    //val url1 = s"https://ipinfo.io/$realIp?token=${env.selectDynamic("ipinfo_token")}"
 
-        //const json = await apiCall(url1);
+    def apiCall(url: String): Future[js.Dynamic] = {
+      js.Dynamic.global.fetch(url).asInstanceOf[js.Promise[js.Dynamic]].toFuture.flatMap { response =>
+        response.text().asInstanceOf[js.Promise[String]].toFuture
+      }.map { result =>
+        js.JSON.parse(result)
+      }
+    }
 
-        function getCurrentDateTimeInWarsaw() {
-            const now = new Date();
-            const options = {
-                timeZone: 'Europe/Warsaw',
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-                hour: '2-digit',
-                minute: '2-digit',
-                second: '2-digit',
-            };
-            return now.toLocaleString('pl-PL', options);
-        }
+    // val json = await apiCall(url1)
+    val json = js.Dynamic.global.json // Map JS global scope for 'json'
 
-        const urlLastPart = request.url
-            .replaceAll("https://", "")
-            .replaceAll("http://", "")
-            .replaceAll(request.headers.get("host") + "/", "")
+    def getCurrentDateTimeInWarsaw(): String = {
+      val now = js.Dynamic.newInstance(js.Dynamic.global.Date)()
+      val options = js.Dynamic.literal(
+        timeZone = "Europe/Warsaw",
+        year = "numeric",
+        month = "2-digit",
+        day = "2-digit",
+        hour = "2-digit",
+        minute = "2-digit",
+        second = "2-digit"
+      )
+      now.applyDynamic("toLocaleString")("pl-PL", options).asInstanceOf[String]
+    }
 
-        if (urlLastPart !== "favicon.ico" && 1 === 0) {
-            const controller = new AbortController();
-            const timeoutId = setTimeout(() => controller.abort(), 3000); // 3 seconds timeout
+    val host = request.headers.get("host").asInstanceOf[String]
+    val urlStr = request.url.asInstanceOf[String]
 
-            try {
-                await fetch('https://ntfy.kuba86.com/cloudflare-workers', {
-                    method: 'POST', // PUT works too
-                    headers: {
-                        'Authorization': `Bearer ${env.ntfy_token}`,
-                        'Title': `Generate | ${realIp}`,
-                        'Priority': 'low',
-                        'Tags': 'cloudflare,Generate'
-                    },
-                    signal: controller.signal,
-                    body:
-                        `${urlLastPart}\n`+
-                        `${getCurrentDateTimeInWarsaw()}\n`+
-                        `IP: ${realIp}\n`+
-                        `Organization: ${json.org}\n`+
-                        `Hostname: ${json.hostname}\n`+
-                        `Country: ${json.country}\n`+
-                        `Region: ${json.region}\n`+
-                        `City: ${json.city}\n`+
-                        `Postal: ${json.postal}\n`+
-                        `Timezone: ${json.timezone}\n`+
-                        `UA: ${request.headers.get("user-agent")}\n`
-                });
-            } catch (error) {
-                if (error.name === 'AbortError') {
-                    console.log('Fetch request timed out after 1 second');
-                } else {
-                    console.error('Fetch error:', error);
-                }
-            } finally {
-                clearTimeout(timeoutId);
+    val urlLastPart = urlStr
+      .replace("https://", "")
+      .replace("http://", "")
+      .replace((if (host == null) "" else host) + "/", "")
+
+    val processFuture: Future[Unit] = if (urlLastPart != "favicon.ico" && 1 == 0) {
+      val controller = js.Dynamic.newInstance(js.Dynamic.global.AbortController)()
+      val timeoutId = js.Dynamic.global.setTimeout(() => controller.abort(), 3000)
+
+      val fetchFuture = js.Dynamic.global.fetch("https://ntfy.kuba86.com/cloudflare-workers", js.Dynamic.literal(
+        method = "POST",
+        headers = js.Dynamic.literal(
+          "Authorization" -> s"Bearer ${env.selectDynamic("ntfy_token")}",
+          "Title" -> s"Generate | $realIp",
+          "Priority" -> "low",
+          "Tags" -> "cloudflare,Generate"
+        ),
+        signal = controller.signal,
+        body = s"$urlLastPart\n" +
+               s"${getCurrentDateTimeInWarsaw()}\n" +
+               s"IP: $realIp\n" +
+               s"Organization: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("org")}\n" +
+               s"Hostname: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("hostname")}\n" +
+               s"Country: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("country")}\n" +
+               s"Region: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("region")}\n" +
+               s"City: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("city")}\n" +
+               s"Postal: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("postal")}\n" +
+               s"Timezone: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("timezone")}\n" +
+               s"UA: ${request.headers.get("user-agent")}\n"
+      )).asInstanceOf[js.Promise[js.Dynamic]].toFuture
+
+      fetchFuture.map(_ => ()).recover { case error: Throwable =>
+        error match {
+          case jsErr: js.JavaScriptException =>
+            val exceptionObj = jsErr.exception.asInstanceOf[js.Dynamic]
+            if (exceptionObj.selectDynamic("name").asInstanceOf[String] == "AbortError") {
+              js.Dynamic.global.console.log("Fetch request timed out after 1 second")
+            } else {
+              js.Dynamic.global.console.error("Fetch error:", exceptionObj)
             }
+          case _ =>
+            js.Dynamic.global.console.error("Fetch error:", error.getMessage)
         }
+      }.map { _ =>
+        js.Dynamic.global.clearTimeout(timeoutId)
+        ()
+      }
+    } else {
+      Future.successful(())
+    }
 
-
-
-        const html = `<!doctype html>
+    processFuture.map { _ =>
+      val html = """<!doctype html>
             <html lang="en" data-bs-theme="dark">
               <head>
                 <meta charset="utf-8">
@@ -156,13 +176,13 @@ export default {
                   }
                 </script>
               </body>
-            </html>
-            `;
+            </html>"""
 
-        return new Response(html, {
-            headers: {
-                'content-type': 'text/html;charset=UTF-8',
-            },
-        });
-    },
-};
+      js.Dynamic.newInstance(js.Dynamic.global.Response)(html, js.Dynamic.literal(
+        headers = js.Dynamic.literal(
+          "content-type" -> "text/html;charset=UTF-8"
+        )
+      ))
+    }.toJSPromise
+  }
+}

--- a/src/index.scala
+++ b/src/index.scala
@@ -6,92 +6,10 @@ import scala.scalajs.js.JSConverters._
 
 @JSExportTopLevel("default")
 object Worker extends js.Object {
-  val fetch: js.Function3[js.Dynamic, js.Dynamic, js.Dynamic, js.Promise[js.Dynamic]] = { (request: js.Dynamic, env: js.Dynamic, ctx: js.Dynamic) =>
-    val realIp = request.headers.get("x-real-ip").asInstanceOf[String]
-    val connectingIp = request.headers.get("cf-connecting-ip").asInstanceOf[String]
-    //val url1 = s"https://ipinfo.io/$realIp?token=${env.selectDynamic("ipinfo_token")}"
-
-    def apiCall(url: String): Future[js.Dynamic] = {
-      js.Dynamic.global.fetch(url).asInstanceOf[js.Promise[js.Dynamic]].toFuture.flatMap { response =>
-        response.text().asInstanceOf[js.Promise[String]].toFuture
-      }.map { result =>
-        js.JSON.parse(result)
-      }
-    }
-
-    // val json = await apiCall(url1)
-    val json = js.Dynamic.global.json // Map JS global scope for 'json'
-
-    def getCurrentDateTimeInWarsaw(): String = {
-      val now = js.Dynamic.newInstance(js.Dynamic.global.Date)()
-      val options = js.Dynamic.literal(
-        timeZone = "Europe/Warsaw",
-        year = "numeric",
-        month = "2-digit",
-        day = "2-digit",
-        hour = "2-digit",
-        minute = "2-digit",
-        second = "2-digit"
-      )
-      now.applyDynamic("toLocaleString")("pl-PL", options).asInstanceOf[String]
-    }
-
-    val host = request.headers.get("host").asInstanceOf[String]
-    val urlStr = request.url.asInstanceOf[String]
-
-    val urlLastPart = urlStr
-      .replace("https://", "")
-      .replace("http://", "")
-      .replace((if (host == null) "" else host) + "/", "")
-
-    val processFuture: Future[Unit] = if (urlLastPart != "favicon.ico" && 1 == 0) {
-      val controller = js.Dynamic.newInstance(js.Dynamic.global.AbortController)()
-      val timeoutId = js.Dynamic.global.setTimeout(() => controller.abort(), 3000)
-
-      val fetchFuture = js.Dynamic.global.fetch("https://ntfy.kuba86.com/cloudflare-workers", js.Dynamic.literal(
-        method = "POST",
-        headers = js.Dynamic.literal(
-          "Authorization" -> s"Bearer ${env.selectDynamic("ntfy_token")}",
-          "Title" -> s"Generate | $realIp",
-          "Priority" -> "low",
-          "Tags" -> "cloudflare,Generate"
-        ),
-        signal = controller.signal,
-        body = s"$urlLastPart\n" +
-               s"${getCurrentDateTimeInWarsaw()}\n" +
-               s"IP: $realIp\n" +
-               s"Organization: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("org")}\n" +
-               s"Hostname: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("hostname")}\n" +
-               s"Country: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("country")}\n" +
-               s"Region: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("region")}\n" +
-               s"City: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("city")}\n" +
-               s"Postal: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("postal")}\n" +
-               s"Timezone: ${if (js.isUndefined(json)) "undefined" else json.selectDynamic("timezone")}\n" +
-               s"UA: ${request.headers.get("user-agent")}\n"
-      )).asInstanceOf[js.Promise[js.Dynamic]].toFuture
-
-      fetchFuture.map(_ => ()).recover { case error: Throwable =>
-        error match {
-          case jsErr: js.JavaScriptException =>
-            val exceptionObj = jsErr.exception.asInstanceOf[js.Dynamic]
-            if (exceptionObj.selectDynamic("name").asInstanceOf[String] == "AbortError") {
-              js.Dynamic.global.console.log("Fetch request timed out after 1 second")
-            } else {
-              js.Dynamic.global.console.error("Fetch error:", exceptionObj)
-            }
-          case _ =>
-            js.Dynamic.global.console.error("Fetch error:", error.getMessage)
-        }
-      }.map { _ =>
-        js.Dynamic.global.clearTimeout(timeoutId)
-        ()
-      }
-    } else {
-      Future.successful(())
-    }
-
-    processFuture.map { _ =>
-      val html = """<!doctype html>
+  val fetch: js.Function3[js.Dynamic, js.Dynamic, js.Dynamic, js.Promise[
+    js.Dynamic
+  ]] = { (request: js.Dynamic, env: js.Dynamic, ctx: js.Dynamic) =>
+    val html = """<!doctype html>
             <html lang="en" data-bs-theme="dark">
               <head>
                 <meta charset="utf-8">
@@ -130,7 +48,7 @@ object Worker extends js.Object {
                       <button class="btn btn-primary btn-sm" type="button" onclick="copyTxt('k86.addy.io');">Copy</button>
                     </div>
                   </div>
-                
+
                   <br>
                   <h3>Password: <button class="btn btn-primary btn-sm" type="button" onclick="generatePassword(20);">Generate</button></h3>
                   <div class="row">
@@ -150,7 +68,7 @@ object Worker extends js.Object {
                     const text = document.getElementById(id).value;
                     navigator.clipboard.writeText(text);
                   }
-                
+
                   function randomStringGenerator(poolOfChars, lengthOfString) {
                     const charsArray = poolOfChars.split("")
                     const charsArrayLength = charsArray.length
@@ -158,19 +76,19 @@ object Worker extends js.Object {
                     crypto.getRandomValues(randomNumbersArray)
                     return Array.from(randomNumbersArray).map((x) => charsArray[x % charsArrayLength]).join("")
                   }
-                
+
                   function generateEmail(size) {
                     const randomEmailUser = randomStringGenerator("wertupadfghjkzcnm234679", size)
                     document.getElementById("username").value = randomEmailUser;
                     document.getElementById("kuba86.com").value = randomEmailUser + "@kuba86.com";
                     document.getElementById("k86.addy.io").value = randomEmailUser + "@k86.addy.io";
                   }
-                  
+
                   const numbers = "0123456789";
                   const lowerLetters = "abcdefghijklmnopqrstuvwxyz";
                   const upperLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
                   const symbols = "-!^_,.";
-                
+
                   function generatePassword(size) {
                     document.getElementById("password").value = randomStringGenerator(numbers+lowerLetters+upperLetters, size)
                   }
@@ -178,11 +96,18 @@ object Worker extends js.Object {
               </body>
             </html>"""
 
-      js.Dynamic.newInstance(js.Dynamic.global.Response)(html, js.Dynamic.literal(
-        headers = js.Dynamic.literal(
-          "content-type" -> "text/html;charset=UTF-8"
+    js.Dynamic.global.Promise
+      .resolve(
+        js.Dynamic.newInstance(js.Dynamic.global.Response)(
+          html,
+          js.Dynamic.literal(
+            headers = js.Dynamic.literal(
+              "content-type" -> "text/html;charset=UTF-8"
+            )
+          )
         )
-      ))
-    }.toJSPromise
+      )
+      .asInstanceOf[js.Promise[js.Dynamic]]
+
   }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "generate"
 main = "src/index.js"
-compatibility_date = "2026-02-01"
+compatibility_date = "2026-06-20"
 routes = [
     { pattern = "generate.kuba86.com", custom_domain = true }
 ]


### PR DESCRIPTION
This PR completes the request to convert the existing JavaScript Cloudflare Worker code to a `scala.js` application using `scala-cli` for compilation.

Changes implemented:
- Replaced the hand-written JavaScript `src/index.js` with `src/index.scala`.
- Handled integration with JS globals dynamically and recreated the HTML page string safely within the new application structure.
- Injected `npm run build` using `scala-cli` as a pre-requisite for both manual `wrangler` deployment and local testing.
- Added `VirtusLab/scala-cli-setup@main` workflow step inside the GitHub Action so `scala-cli` is appropriately installed before `wrangler` deploys.
- Added the generated `src/index.js` and `.scala-build/` to `.gitignore`.

---
*PR created automatically by Jules for task [14773878455340472591](https://jules.google.com/task/14773878455340472591) started by @kuba86*